### PR TITLE
Create docker-compose.mssql.yml

### DIFF
--- a/docker-compose.mssql.yml
+++ b/docker-compose.mssql.yml
@@ -1,0 +1,95 @@
+# BEFORE RUNNING: Set jpproject to 127.0.0.1 in your hosts file
+# RUN: docker-compose -f docker-compose.mssql.yml up
+version: "3"
+
+services:
+
+    #############################
+    # Database
+    #############################
+    jpdatabase:
+      image: mcr.microsoft.com/mssql/server:2017-latest
+      restart: unless-stopped
+      expose: 
+        - "1433"
+      environment:
+          ACCEPT_EULA: "Y"
+          # SQL SA Password must be: min 8 characters, upper, lower and number or special character
+          MSSQL_SA_PASSWORD: Let_Me_In
+    
+    #############################
+    # Server SSO
+    #############################
+    jpproject:
+        image: "jpproject-sso"
+        build: 
+          context: .
+          dockerfile: sso.dockerfile
+        ports:
+            - "5000:5000"
+        links:
+            - jpdatabase
+        depends_on:
+            - jpdatabase
+        environment: 
+            ASPNETCORE_ENVIRONMENT: Development
+            ASPNETCORE_URLS: http://+:5000
+            # using sa@tempdb as sql server image doesn't have envvars to create a database or user with the startup
+            CUSTOMCONNSTR_SSOConnection: "Server=jpdatabase;Database=tempdb;User ID=sa;Password=Let_Me_In;MultipleActiveResultSets=true"
+            ApplicationSettings:EnableExternalProviders: "false" # Because Auth url is http://jpproject (modified by host to point to 127.0.0.1), then Google and Facebook reject it.
+            ApplicationSettings:DatabaseType: SqlServer
+            ApplicationSettings:DefaultUser: bruno
+            ApplicationSettings:DefaultPass: Pa$$word123
+            ApplicationSettings:DefaultEmail: bhdebrito@gmail.com
+            ApplicationSettings:UserManagementURL: http://localhost:4200
+            ApplicationSettings:IS4AdminUi: http://localhost:4300
+            ApplicationSettings:ResourceServerURL: http://localhost:5003
+            CertificateOptions:Type: Temporary
+
+    # #############################
+    # # Management API
+    # #############################
+    jpproject-api:
+        image: jpproject-api
+        build: 
+          context: .
+          dockerfile: api.dockerfile
+        ports:
+            - "5003:80"
+        depends_on:
+            - jpdatabase
+        environment: 
+            ASPNETCORE_ENVIRONMENT: "Development"
+            ASPNETCORE_URLS: http://+
+            # using sa@tempdb as sql server image doesn't have envvars to create a database or user with the startup
+            CUSTOMCONNSTR_SSOConnection: "Server=jpdatabase;Database=tempdb;User ID=sa;Password=Let_Me_In;MultipleActiveResultSets=true"
+            ApplicationSettings:Authority: "http://jpproject:5000"
+            ApplicationSettings:DatabaseType: SqlServer
+
+    #############################
+    # User management UI
+    #############################
+    user-ui:
+        image: jpproject-user-management-ui
+        build: 
+          context: .
+          dockerfile: ui-user-management.dockerfile
+        depends_on:
+            - jpproject-api
+            - jpproject
+        ports:
+            - 4200:80
+
+    #############################
+    # Admin Ui
+    #############################
+    admin-ui:
+        image: jpproject-admin-ui
+        build: 
+          context: .
+          dockerfile: admin-ui.dockerfile
+        depends_on:
+            - jpproject-api
+            - jpproject
+        ports:
+            - 4300:80


### PR DESCRIPTION
Add Docker compose example for using MSSQL.  It uses the `sa` user and `tempdb` because the image doesn't allow for injection of another user and/or database.  

Future: 
- create a decendent mssql dockerfile that does allow and create a database user and a database to target