### PR TITLE
Docs link corrected to the relative path.

### DIFF
--- a/docs/configuration/certificate.rst
+++ b/docs/configuration/certificate.rst
@@ -11,4 +11,4 @@ Open up a PowerShell terminal and run the script. It’ll ask you for a certific
 Change Config file
 ^^^^^^^^^^^^^^^^^^
 
-If a certificate is generated, to use it, change the appsettings.json. See `docs <quickstarts/ambient_variables.html>`_ for more info
+If a certificate is generated, to use it, change the appsettings.json. See `docs <../quickstarts/ambient_variables.html>`_ for more info


### PR DESCRIPTION
it should be ../quickstart, not configuration/quickstart. I have corrected the relative path and now it should redirect to the relevant page.